### PR TITLE
fix: removed duplicate launch-pcsx2 IPC handler

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,7 +1,7 @@
 // main.js
-const { app, BrowserWindow, ipcMain, shell } = require("electron");
+const { app, BrowserWindow, ipcMain } = require("electron");
 const path = require("path");
-const { exec } = require("child_process");
+const { spawn } = require("child_process");
 
 // REQUIRED for correct Windows taskbar & pinned icon
 app.setAppUserModelId("com.yourname.gamelauncher");
@@ -54,38 +54,24 @@ ipcMain.handle("launch-game", async (_evt, command) => {
   console.log("Launching via Electron (launch-game):", command);
 
   return new Promise((resolve) => {
-    exec(command, { shell: "cmd.exe", windowsHide: false }, (err, stdout, stderr) => {
-      if (stdout) console.log("stdout:", stdout);
-      if (stderr) console.log("stderr:", stderr);
+    const parts = command.match(/(?:[^\s"]+|"[^"]*")+/g) || [];
+    const exe = parts[0].replace(/"/g, "");
+    const args = parts.slice(1).map((a) => a.replace(/"/g, ""));
 
-      if (err) {
-        resolve({
-          ok: false,
-          error: String(err),
-          stderr: String(stderr || ""),
-        });
-      } else {
-        resolve({ ok: true });
-      }
+    const child = spawn(exe, args, {
+      detached: true,
+      stdio: "ignore",
     });
+
+    child.unref();
+
+    child.on("error", (err) => {
+      console.error("Launch error:", err);
+      resolve({ ok: false, error: String(err) });
+    });
+
+    resolve({ ok: true });
   });
-});
-
-/*
-|--------------------------------------------------------------------------
-| PCSX2 DIRECT LAUNCHER
-|--------------------------------------------------------------------------
-*/
-ipcMain.handle("launch-pcsx2", async (_evt, exePath) => {
-  console.log("Launching PCSX2:", exePath);
-
-  const result = await shell.openPath(exePath);
-
-  if (result) {
-    return { ok: false, error: result };
-  }
-
-  return { ok: true };
 });
 
 app.whenReady().then(() => {

--- a/preload.js
+++ b/preload.js
@@ -7,6 +7,4 @@ contextBridge.exposeInMainWorld("electronAPI", {
   getAppVersion: () => ipcRenderer.invoke("get-app-version"),
   // Launch a game using generic command
   launchGame: (command) => ipcRenderer.invoke("launch-game", command),
-  //launch PCSX2 directory
-  launchPCSX2: (exePath) => ipcRenderer.invoke("launch-pcsx2", exePath),
 });

--- a/src/App.js
+++ b/src/App.js
@@ -177,14 +177,6 @@ export default function App() {
     return true;
   };
 
-  const ensureElectronPCSX2 = () => {
-    if (!(window.electronAPI && window.electronAPI.launchPCSX2)) {
-      console.error("Electron bridge not found: launchPCSX2");
-      return false;
-    }
-    return true;
-  };
-
   // ---------- ADD ----------
   const addSteamGame = () => {
     if (!newSteamGame.trim() || !steamId.trim()) return;
@@ -265,8 +257,9 @@ export default function App() {
   };
 
   const launchPcsx2Only = () => {
-    if (!ensureElectronPCSX2()) return;
-    window.electronAPI.launchPCSX2(paths.pcsx2);
+    if (!ensureElectronGame()) return;
+    const command = `"${paths.pcsx2}"`;
+    window.electronAPI.launchGame(command);
   };
 
   const launchRpcs3Only = () => {


### PR DESCRIPTION
## What this changes

- Removes duplicate `launch-pcsx2` IPC handler from `main.js`
- Removes `launchPCSX2` bridge from `preload.js`
- Removes `ensureElectronPCSX2` helper from `App.js`
- Updates `launchPcsx2Only` to route through `launchGame`
- Replaces `exec()` with `spawn()` for cleaner process handling

## Why this matters

- PCSX2 was launching two instances on every game click
- `shell.openPath()` was opening a bare PCSX2 window with no ISO argument
- Single unified launch handler eliminates the duplicate window
- `spawn()` with `detached: true` lets the game run independently of Electron

## Testing

- Manually verified in dev mode
- Launched PCSX2 game and confirmed single window only
- Confirmed other platforms (RPCS3, GOG, Steam) unaffected

## Notes
Closes #5