### PR TITLE
feat: add playtime tracking for RPCS3, PCSX2, GOG, & Steam games

### DIFF
--- a/main.js
+++ b/main.js
@@ -8,10 +8,27 @@ app.setAppUserModelId("com.yourname.gamelauncher");
 
 const isDev = !app.isPackaged;
 
+/*
+|--------------------------------------------------------------------------
+| PLAY TIME TRACKER
+|--------------------------------------------------------------------------
+| When a game launches, we store the start time + game ID.
+| When the process exits, we calculate elapsed seconds and
+| send it back to the renderer via webContents.send().
+*/
+let mainWindow = null;
+
+// Tracks running games: Map<exeKey, { pid, startTime, gameId }>
+const activeGames = new Map();
+function getExeKey(exePath) {
+
+  return exePath.toLowerCase().trim();
+}
+
 function createWindow() {
-  const win = new BrowserWindow({
-    width: 1300,
-    height: 900,
+  mainWindow = new BrowserWindow({
+    width: 1400,
+    height: 1100,
 
     // Window title (kills "React App")
     title: "Game Launcher",
@@ -27,14 +44,14 @@ function createWindow() {
   });
 
   if (isDev) {
-    win.loadURL("http://localhost:3000");
+    mainWindow.loadURL("http://localhost:3000");
   } else {
-    win.loadFile(path.join(__dirname, "build", "index.html"));
+    mainWindow.loadFile(path.join(__dirname, "build", "index.html"));
   }
 
   // Force title after load (Windows sometimes overrides)
-  win.webContents.once("did-finish-load", () => {
-    win.setTitle("Game Launcher");
+  mainWindow.webContents.once("did-finish-load", () => {
+    mainWindow.setTitle("Game Launcher");
   });
 }
 /*
@@ -47,11 +64,18 @@ ipcMain.handle("get-app-version", async () => {
 });
 /*
 |--------------------------------------------------------------------------
-| GENERIC COMMAND LAUNCHER
+| GENERIC COMMAND LAUNCHER - NOW WITH PLAY TIME TRACKING
 |--------------------------------------------------------------------------
+| Accepts an optional gameId so we know which game to update
+| when the process exits.
+|
+| The renderer calls:
+|   launchGame(command)           ← old way, still works
+|   launchGame(command, gameId)   ← new way, enables time tracking
 */
-ipcMain.handle("launch-game", async (_evt, command) => {
+ipcMain.handle("launch-game", async (_evt, command, gameId) => {
   console.log("Launching via Electron (launch-game):", command);
+  if (gameId) console.log("Tracking play time for gameId:", gameId);
 
   return new Promise((resolve) => {
     const parts = command.match(/(?:[^\s"]+|"[^"]*")+/g) || [];
@@ -63,14 +87,47 @@ ipcMain.handle("launch-game", async (_evt, command) => {
       stdio: "ignore",
     });
 
-    child.unref();
+    const exeKey = getExeKey(exe);
+
+    // ── TRACK: store start time if we have a gameId ──
+    if (gameId) {
+      activeGames.set(exeKey, {
+        pid: child.pid,
+        startTime: Date.now(),
+        gameId: gameId,
+      });
+    }
+
+    // ── ON EXIT: calculate elapsed time and notify renderer ──
+    child.on("exit", (code) => {
+      const tracked = activeGames.get(exeKey);
+      if (tracked && tracked.gameId) {
+        const elapsedSeconds = Math.floor((Date.now() - tracked.startTime) / 1000);
+        console.log(`Game exited (${tracked.gameId}): played for ${elapsedSeconds}s`);
+
+        // Send elapsed time to the renderer
+        if (mainWindow && !mainWindow.isDestroyed()) {
+          mainWindow.webContents.send("game-closed", {
+            gameId: tracked.gameId,
+            elapsedSeconds: elapsedSeconds,
+          });
+        }
+
+        activeGames.delete(exeKey);
+      }
+    });
 
     child.on("error", (err) => {
       console.error("Launch error:", err);
+      activeGames.delete(exeKey);
       resolve({ ok: false, error: String(err) });
     });
 
-    resolve({ ok: true });
+    // unref so our app can still close, but we keep the
+    // child reference alive in activeGames for tracking
+    child.unref();
+
+    resolve({ ok: true, pid: child.pid });
   });
 });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "game-launcher",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Unified launcher for Steam, GOG, RPCS3, and PCSX2",
   "author": "You",
   "private": true,

--- a/preload.js
+++ b/preload.js
@@ -6,5 +6,10 @@ contextBridge.exposeInMainWorld("electronAPI", {
   // Get app version from Electron
   getAppVersion: () => ipcRenderer.invoke("get-app-version"),
   // Launch a game using generic command
-  launchGame: (command) => ipcRenderer.invoke("launch-game", command),
+  launchGame: (command, gameId) => ipcRenderer.invoke("launch-game", command, gameId),
+  // Listen for when a game process exits
+  // Callback receives: { gameId, elapsedSeconds }
+  onGameClosed: (callback) => {
+    ipcRenderer.on("game-closed", (_event, data) => callback(data));
+  },
 });

--- a/src/App.js
+++ b/src/App.js
@@ -28,6 +28,20 @@ import {
 import { CSS } from "@dnd-kit/utilities";
 import { restrictToVerticalAxis, restrictToParentElement } from "@dnd-kit/modifiers";
 
+/*
+|--------------------------------------------------------------------------
+| FORMAT PLAY TIME — converts total seconds into a readable string
+|--------------------------------------------------------------------------
+*/
+function formatPlayTime(totalSeconds) {
+  if (!totalSeconds || totalSeconds <= 0) return null;
+  if (totalSeconds < 60) return "< 1 min";
+  const hours = totalSeconds / 3600;
+  if (hours >= 1) return `${hours.toFixed(1)}h`;
+  const minutes = Math.floor(totalSeconds / 60);
+  return `${minutes}m`;
+}
+
 function SortableGameRow({ game, onPlay, onRemove }) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: String(game.id),
@@ -38,6 +52,8 @@ function SortableGameRow({ game, onPlay, onRemove }) {
     transition,
     opacity: isDragging ? 0.85 : 1,
   };
+
+  const playTime = formatPlayTime(game.totalPlayTime);
 
   return (
     <div
@@ -59,7 +75,12 @@ function SortableGameRow({ game, onPlay, onRemove }) {
         <div className="min-w-0">
           <p className="font-medium truncate">{game.name}</p>
           {game.lastPlayed && (
-            <p className="text-sm text-gray-400">Last Played: {game.lastPlayed}</p>
+            <p className="text-sm text-gray-400">
+              Last Played: {game.lastPlayed}
+              {playTime && (
+                <span className="text-cyan-400 ml-0">⏱{playTime} played</span>
+              )}
+            </p>
           )}
         </div>
       </div>
@@ -168,6 +189,32 @@ export default function App() {
     localStorage.setItem("rpcs3Games", JSON.stringify(rpcs3Games));
   }, [rpcs3Games]);
 
+  /*
+  |--------------------------------------------------------------------------
+  | LISTEN FOR GAME CLOSED — accumulate play time
+  |--------------------------------------------------------------------------
+  */
+  useEffect(() => {
+    if (!(window.electronAPI && window.electronAPI.onGameClosed)) return;
+
+    window.electronAPI.onGameClosed((data) => {
+      const { gameId, elapsedSeconds } = data;
+      console.log(`Game closed: ${gameId}, played for ${elapsedSeconds}s`);
+
+      const updater = (prev) =>
+        prev.map((g) =>
+          String(g.id) === String(gameId)
+            ? { ...g, totalPlayTime: (g.totalPlayTime || 0) + elapsedSeconds }
+            : g
+        );
+
+      setSteamGames(updater);
+      setGogGames(updater);
+      setPcsx2Games(updater);
+      setRpcs3Games(updater);
+    });
+  }, []);
+
   // ---------- HELPERS ----------
   const ensureElectronGame = () => {
     if (!(window.electronAPI && window.electronAPI.launchGame)) {
@@ -183,7 +230,7 @@ export default function App() {
 
     setSteamGames((prev) => [
       ...prev,
-      { id: Date.now(), name: newSteamGame.trim(), steamId: steamId.trim(), lastPlayed: null },
+      { id: Date.now(), name: newSteamGame.trim(), steamId: steamId.trim(), lastPlayed: null, totalPlayTime: 0 },
     ]);
 
     setNewSteamGame("");
@@ -195,7 +242,7 @@ export default function App() {
 
     setGogGames((prev) => [
       ...prev,
-      { id: Date.now(), name: newGogGame.trim(), gogId: gogId.trim(), lastPlayed: null },
+      { id: Date.now(), name: newGogGame.trim(), gogId: gogId.trim(), lastPlayed: null, totalPlayTime: 0 },
     ]);
 
     setNewGogGame("");
@@ -207,7 +254,7 @@ export default function App() {
 
     setPcsx2Games((prev) => [
       ...prev,
-      { id: Date.now(), name: newPcsx2Game.trim(), isoPath: pcsx2IsoPath.trim(), lastPlayed: null },
+      { id: Date.now(), name: newPcsx2Game.trim(), isoPath: pcsx2IsoPath.trim(), lastPlayed: null, totalPlayTime: 0 },
     ]);
 
     setNewPcsx2Game("");
@@ -219,7 +266,7 @@ export default function App() {
 
     setRpcs3Games((prev) => [
       ...prev,
-      { id: Date.now(), name: newRpcs3Game.trim(), gamePath: rpcs3GamePath.trim(), lastPlayed: null },
+      { id: Date.now(), name: newRpcs3Game.trim(), gamePath: rpcs3GamePath.trim(), lastPlayed: null, totalPlayTime: 0 },
     ]);
 
     setNewRpcs3Game("");
@@ -238,7 +285,7 @@ export default function App() {
     if (!ensureElectronGame()) return;
 
     const command = `"${paths.gog}" /command=runGame /gameId=${game.gogId}`;
-    window.electronAPI.launchGame(command);
+    window.electronAPI.launchGame(command, game.id);
 
     setGogGames((prev) =>
       prev.map((g) => (g.id === game.id ? { ...g, lastPlayed: new Date().toLocaleString() } : g))
@@ -249,7 +296,7 @@ export default function App() {
     if (!ensureElectronGame()) return;
 
     const command = `"${paths.pcsx2}" "${game.isoPath}"`;
-    window.electronAPI.launchGame(command);
+    window.electronAPI.launchGame(command, game.id);
 
     setPcsx2Games((prev) =>
       prev.map((g) => (g.id === game.id ? { ...g, lastPlayed: new Date().toLocaleString() } : g))
@@ -272,7 +319,7 @@ export default function App() {
     if (!ensureElectronGame()) return;
 
     const command = `"${paths.rpcs3}" --no-gui "${game.gamePath}"`;
-    window.electronAPI.launchGame(command);
+    window.electronAPI.launchGame(command, game.id);
 
     setRpcs3Games((prev) =>
       prev.map((g) => (g.id === game.id ? { ...g, lastPlayed: new Date().toLocaleString() } : g))


### PR DESCRIPTION
## What this changes
- Adds `activeGames` Map to `main.js` to track game process start/exit times
- Adds `gameId` parameter to `launch-game` IPC handler for per-game tracking
- Sends `game-closed` event back to renderer with elapsed seconds on process exit
- Adds `onGameClosed` IPC listener to `preload.js`
- Adds `formatPlayTime()` helper to `App.js` (converts seconds → `11m`, `1.5h`, etc.)
- Displays accumulated play time inline next to last played date with ⏱ icon
- Adds `totalPlayTime` field to all new game entries
- Increases default window width from `1300` to `1400` & default length from 900 to 1100

## Why this matters
- Players can see how much time they've spent on each game at a glance
- No need to check individual launcher apps (Steam, GOG, PCSX2) for play time
- Time tracking is automatic — starts when the game launches, stops when it exits
- Existing games without `totalPlayTime` are handled gracefully

## Testing
- Manually verified in dev mode & build 
- Launched PCSX2 game, played for ~11 minutes, confirmed time appeared after closing
- Confirmed play time accumulates across multiple sessions
- Confirmed other platforms (RPCS3, GOG, Steam) unaffected
- Verified layout at default and resized window widths

## Notes
Closes #7 